### PR TITLE
ref: refined createDagJWS api and added documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dids",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Typescript library for interacting with DIDs",
   "main": "lib/index.js",
   "files": [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,40 @@
 import dagCBOR from 'ipld-dag-cbor'
+import CID from 'cids'
 import base64url from 'base64url'
 
-interface EncodedPayload {
-  cid: string
-  linkedBlock: string
+export interface EncodedPayload {
+  cid: CID
+  linkedBlock: Uint8Array
 }
 
 export async function encodePayload(payload: Record<string, any>): Promise<EncodedPayload> {
   const block = dagCBOR.util.serialize(payload)
   return {
-    cid: base64url.encode(Buffer.from((await dagCBOR.util.cid(block)).bytes)),
-    linkedBlock: base64url.encode(block),
+    cid: await dagCBOR.util.cid(block),
+    linkedBlock: block,
+  }
+}
+
+export function u8aToBase64(bytes: Uint8Array): string {
+  return base64url.encode(Buffer.from(bytes))
+}
+
+interface JWSSignature {
+  protected: string
+  signature: string
+}
+
+export interface DagJWS {
+  payload: string
+  signatures: Array<JWSSignature>
+  link: CID
+}
+
+export function toDagJWS(jws: string, cid: CID): DagJWS {
+  const [protectedHeader, payload, signature] = jws.split('.')
+  return {
+    payload,
+    signatures: [{ protected: protectedHeader, signature }],
+    link: cid,
   }
 }

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -3,7 +3,7 @@
 import { DIDDocument, Resolver } from 'did-resolver'
 
 import { DID, DIDProvider } from '../src'
-import { encodePayload } from '../src/utils'
+import { encodePayload, u8aToBase64 } from '../src/utils'
 
 describe('DID class', () => {
   describe('provider behavior', () => {
@@ -182,7 +182,7 @@ describe('DID class', () => {
           send: jest.fn((req: { id: string }) => {
             let result
             if (authCalled) {
-              result = { jws: '5678' }
+              result = { jws: '5678.234.4324' }
             } else {
               authCalled = true
               result = { did: 'did:3:1234' }
@@ -205,7 +205,11 @@ describe('DID class', () => {
         const res = await did.createDagJWS(data)
         const encPayload = await encodePayload(data)
         expect(res).toEqual({
-          jws: '5678',
+          jws: {
+            link: encPayload.cid,
+            payload: '234',
+            signatures: [{ protected: '5678', signature: '4324' }],
+          },
           linkedBlock: encPayload.linkedBlock,
         })
 
@@ -217,8 +221,8 @@ describe('DID class', () => {
           method: 'did_createJWS',
           params: {
             did: 'did:3:1234',
-            payload: encPayload.cid,
-            linkedBlock: encPayload.linkedBlock,
+            payload: u8aToBase64(encPayload.cid.bytes),
+            linkedBlock: u8aToBase64(encPayload.linkedBlock),
           },
         })
       })


### PR DESCRIPTION
Updates the `createDagJWS` method so that it plays nicer with ipfs. You can now put the encoded block of the payload directly into the ipfs blockstore (see readme for an example).