### PR TITLE
feat: return payload in verifyJWS method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.1.0 (2020-11-26)
+feat: return payload in verifyJWS method
+
 ## v1.0.0 (2020-11-25)
 This release aligns this implementation with EIP2844.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dids",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Typescript library for interacting with DIDs",
   "main": "lib/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export interface CreateJWSResult {
 
 export interface VerifyJWSResult {
   kid: string
+  payload?: Record<string, any>
 }
 
 export interface CreateJWEOptions {
@@ -215,9 +216,15 @@ export class DID {
     const { publicKey } = await this.resolve(kid)
     // verifyJWS will throw an error if the signature is invalid
     verifyJWS(jws, publicKey)
+    let payload
+    try {
+      payload = base64urlToJSON(jws.split('.')[1])
+    } catch (e) {
+      // If an error is thrown it means that the payload is a CID.
+    }
     // In the future, returned obj will need to contain
     // more metadata about the key that signed the jws.
-    return { kid }
+    return { kid, payload }
   }
 
   /**

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -278,6 +278,7 @@ describe('DID class', () => {
 
     describe('`verifyJWS method`', () => {
       const resolverRegistry = {
+        ...MOCK_RESOLVER_REGISTRY,
         '3': async () => ({
           '@context': "https://w3id.org/did/v1",
           id: "did:3:bagcqceraskxqzx47ivokjqofwoyuyb23tiaepdrazq5rlzn2hx7kmyaczwoa",
@@ -311,6 +312,18 @@ describe('DID class', () => {
           }]
         }
         expect(await did.verifyJWS(jws)).toEqual({ kid: 'did:3:bagcqceraskxqzx47ivokjqofwoyuyb23tiaepdrazq5rlzn2hx7kmyaczwoa?version-id=0#kWMXMMqk5WsotQm' })
+      })
+
+      test('correctly verifies jws auth JWS', async () => {
+        const did = new DID({ resolver: resolverRegistry })
+        expect(await did.verifyJWS(MOCK_AUTH_JWS)).toEqual({
+          kid: 'did:key:z6MkoCHYXLHAWHPPVMBSe9nQcteTmnY32GdBQMYp13cdacDU#z6MkoCHYXLHAWHPPVMBSe9nQcteTmnY32GdBQMYp13cdacDU',
+          payload: {
+            did: "did:key:z6MkoCHYXLHAWHPPVMBSe9nQcteTmnY32GdBQMYp13cdacDU",
+            exp: 1606236374,
+            nonce: "rWCXyH1otp5/F78tycckgg",
+          }
+        })
       })
     })
 


### PR DESCRIPTION
Conveniently get the payload when you verify a JWS.