### PR TITLE
chore: update cids and dag-jose-utils

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,6 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "testRegex": ".(spec|test).ts$",
+  "testEnvironment": "node",
+  "resolver": "jest-resolver-enhanced"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
       "dependencies": {
         "@stablelib/random": "^1.0.1",
         "cids": "^1.1.6",
-        "dag-jose-utils": "^0.1.1",
+        "dag-jose-utils": "^1.0.0",
         "did-jwt": "^5.6.1",
         "did-resolver": "^3.1.0",
+        "multiformats": "^9.4.10",
         "query-string": "^7.0.0",
         "rpc-utils": "^0.3.4",
         "uint8arrays": "^2.1.5"
@@ -1704,6 +1705,20 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.5.tgz",
+      "integrity": "sha512-nSWGvqhwE9nHsrBx8YL4TiwhsitLhJ54Md5BMCUdK+s10QPxYsO7l/rRxU9bLV/L13WUTfLEll2K3Q2ijlZCWw==",
+      "dependencies": {
+        "cborg": "^1.2.1",
+        "multiformats": "^8.0.3"
+      }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3831,45 +3846,10 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3936,15 +3916,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -3993,6 +3964,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
       "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
+    },
+    "node_modules/cborg": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.3.tgz",
+      "integrity": "sha512-iUweYinQpR48eXxcmEoZlixY2eo+vDCGc5utNwXV0oYhmowHU/2DwcSiJ4xU1l7niwXOR91pcE3zEgZl4VoFAQ==",
+      "bin": {
+        "cborg": "cli.js"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -4148,11 +4127,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4222,21 +4196,18 @@
       "dev": true
     },
     "node_modules/dag-jose-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-0.1.1.tgz",
-      "integrity": "sha512-fFRgalfWAgz1zwjxEwlrQY0p+23zLRpvQm7IfPTiMUEXL7zrW/PBmNvmcs9KQphRP7icRzNM0nFxKNbpK2v4aw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-1.0.0.tgz",
+      "integrity": "sha512-ozUlCKI+8YOPJrP/FQfVjUXIT/wtqSPQ6krR5C9lwAEQt0bNHhdJ9K886Hp6nn5apvAD0BurIHx4SsCnYHcwTg==",
       "dependencies": {
-        "cids": "^1.1.6",
-        "ipld-dag-cbor": "^0.17.1",
-        "multihashes": "^4.0.2",
-        "uint8arrays": "^2.1.4",
-        "varint": "^6.0.0"
+        "@ipld/dag-cbor": "^5.0.5",
+        "multiformats": "^8.0.5"
       }
     },
-    "node_modules/dag-jose-utils/node_modules/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    "node_modules/dag-jose-utils/node_modules/multiformats": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
     },
     "node_modules/data-urls": {
       "version": "2.0.0",
@@ -4319,11 +4290,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -4459,11 +4425,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/err-code": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/es-abstract": {
       "version": "1.17.7",
@@ -5645,11 +5606,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5747,23 +5703,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/ipld-dag-cbor": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.1.tgz",
-      "integrity": "sha512-Bakj/cnxQBdscORyf4LRHxQJQfoaY8KWc7PWROQgX+aw5FCzBt8ga0VM/59K+ABOznsqNvyLR/wz/oYImOpXJw==",
-      "dependencies": {
-        "borc": "^2.1.2",
-        "cids": "^1.0.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "uint8arrays": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
     "node_modules/is-boolean-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
@@ -5799,11 +5738,6 @@
       "bin": {
         "is-ci": "bin.js"
       }
-    },
-    "node_modules/is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
     "node_modules/is-core-module": {
       "version": "2.4.0",
@@ -5945,14 +5879,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "node_modules/iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -9321,14 +9247,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "dependencies": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "node_modules/json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -9612,65 +9530,10 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
-      "dependencies": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      }
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashing-async": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
-      "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/murmurhash3js-revisited": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/multiformats": {
+      "version": "9.4.10",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.10.tgz",
+      "integrity": "sha512-BwWGvgqB/5J/cnWaOA0sXzJ+UGl+kyFAw3Sw1L6TN4oad34C9OpW+GCpYTYPDp4pUaXDC1EjvB3yv9Iodo1EhA=="
     },
     "node_modules/nanoid": {
       "version": "3.1.22",
@@ -10174,19 +10037,6 @@
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
       "dev": true
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -10409,11 +10259,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -10647,14 +10492,6 @@
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -11186,11 +11023,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.2.0",
@@ -12660,6 +12492,22 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
+        }
+      }
+    },
+    "@ipld/dag-cbor": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.5.tgz",
+      "integrity": "sha512-nSWGvqhwE9nHsrBx8YL4TiwhsitLhJ54Md5BMCUdK+s10QPxYsO7l/rRxU9bLV/L13WUTfLEll2K3Q2ijlZCWw==",
+      "requires": {
+        "cborg": "^1.2.1",
+        "multiformats": "^8.0.3"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "8.0.6",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
         }
       }
     },
@@ -14341,39 +14189,10 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-    },
-    "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
     "bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -14427,15 +14246,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -14474,6 +14284,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
       "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
+    },
+    "cborg": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.3.tgz",
+      "integrity": "sha512-iUweYinQpR48eXxcmEoZlixY2eo+vDCGc5utNwXV0oYhmowHU/2DwcSiJ4xU1l7niwXOR91pcE3zEgZl4VoFAQ=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -14603,11 +14418,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -14673,21 +14483,18 @@
       }
     },
     "dag-jose-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-0.1.1.tgz",
-      "integrity": "sha512-fFRgalfWAgz1zwjxEwlrQY0p+23zLRpvQm7IfPTiMUEXL7zrW/PBmNvmcs9KQphRP7icRzNM0nFxKNbpK2v4aw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-1.0.0.tgz",
+      "integrity": "sha512-ozUlCKI+8YOPJrP/FQfVjUXIT/wtqSPQ6krR5C9lwAEQt0bNHhdJ9K886Hp6nn5apvAD0BurIHx4SsCnYHcwTg==",
       "requires": {
-        "cids": "^1.1.6",
-        "ipld-dag-cbor": "^0.17.1",
-        "multihashes": "^4.0.2",
-        "uint8arrays": "^2.1.4",
-        "varint": "^6.0.0"
+        "@ipld/dag-cbor": "^5.0.5",
+        "multiformats": "^8.0.5"
       },
       "dependencies": {
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        "multiformats": {
+          "version": "8.0.6",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
         }
       }
     },
@@ -14754,11 +14561,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -14869,11 +14671,6 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
-    },
-    "err-code": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "es-abstract": {
       "version": "1.17.7",
@@ -15774,11 +15571,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -15851,19 +15643,6 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
-    "ipld-dag-cbor": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.1.tgz",
-      "integrity": "sha512-Bakj/cnxQBdscORyf4LRHxQJQfoaY8KWc7PWROQgX+aw5FCzBt8ga0VM/59K+ABOznsqNvyLR/wz/oYImOpXJw==",
-      "requires": {
-        "borc": "^2.1.2",
-        "cids": "^1.0.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "uint8arrays": "^2.1.3"
-      }
-    },
     "is-boolean-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
@@ -15887,11 +15666,6 @@
       "requires": {
         "ci-info": "^3.1.1"
       }
-    },
-    "is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
     "is-core-module": {
       "version": "2.4.0",
@@ -15994,11 +15768,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -18576,14 +18345,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -18810,50 +18571,10 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "requires": {
-        "@multiformats/base-x": "^4.0.1"
-      }
-    },
-    "multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
-      "requires": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      }
-    },
-    "multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "requires": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      }
-    },
-    "multihashing-async": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
-      "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^2.1.3"
-      }
-    },
-    "murmurhash3js-revisited": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+    "multiformats": {
+      "version": "9.4.10",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.10.tgz",
+      "integrity": "sha512-BwWGvgqB/5J/cnWaOA0sXzJ+UGl+kyFAw3Sw1L6TN4oad34C9OpW+GCpYTYPDp4pUaXDC1EjvB3yv9Iodo1EhA=="
     },
     "nanoid": {
       "version": "3.1.22",
@@ -19230,16 +18951,6 @@
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
       "dev": true
     },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -19400,11 +19111,6 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -19590,14 +19296,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "string-length": {
       "version": "4.0.2",
@@ -20008,11 +19706,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/random": "^1.0.1",
-        "cids": "^1.1.6",
         "dag-jose-utils": "^1.0.0",
         "did-jwt": "^5.6.1",
-        "did-resolver": "^3.1.0",
+        "did-resolver": "^3.1.3",
         "multiformats": "^9.4.10",
-        "query-string": "^7.0.0",
-        "rpc-utils": "^0.3.4",
-        "uint8arrays": "^2.1.5"
+        "query-string": "^7.0.1",
+        "rpc-utils": "^0.4.0",
+        "uint8arrays": "^3.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.14.6",
@@ -2837,11 +2836,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4003,56 +3997,6 @@
       "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
       "dev": true
     },
-    "node_modules/cids": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.6.tgz",
-      "integrity": "sha512-5P+Jas2bVpjiHibp/SOwKY+v7JhAjTChaAZN+vCIrsWXn/JZV0frX22Vp5zZgEyJRPco79pX+yNQ2S3LkRukHQ==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.1",
-        "uint8arrays": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/cids/node_modules/multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/cids/node_modules/multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
-      "dependencies": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      }
-    },
-    "node_modules/cids/node_modules/multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
@@ -4318,10 +4262,18 @@
         "uint8arrays": "^2.1.3"
       }
     },
+    "node_modules/did-jwt/node_modules/uint8arrays": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
+      "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/did-resolver": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.1.0.tgz",
-      "integrity": "sha512-uf3/4LfHoDn3Ek8bFegO72OemHMytBhAkud6CA1HlB5I0iVwrCpG4oh+DA6DXUuBdhrA0cY4cGz1D0VNDTlgnw=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.1.3.tgz",
+      "integrity": "sha512-ab8y90tSiDkTdfddXRC9Qcb1QSd568aC6+OgFTrcE4rs1vQAZOil+VqXHDu+Ff/UvhxlckPO8oJtp86iICZG0w=="
     },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
@@ -10018,9 +9970,9 @@
       }
     },
     "node_modules/query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -10249,10 +10201,9 @@
       }
     },
     "node_modules/rpc-utils": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.3.4.tgz",
-      "integrity": "sha512-VmaweXLRpOO2U0FX3Prb88KS0xxkpJK+pJKupR+TagvBmmEetSmvEz+SGTuKwhR9tdSFmjrqt1QSK53Vltapww==",
-      "license": "(Apache-2.0 OR MIT)",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.4.0.tgz",
+      "integrity": "sha512-XBvam3jhcD4d66kFRGjr0cAwJNf8v8eXeJNN187jDGvHuQO9Dugu01WCAghojAbSOcdimCBBz77WNVU1j2+Uig==",
       "dependencies": {
         "nanoid": "^3.1.21"
       },
@@ -10978,24 +10929,11 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.5.tgz",
-      "integrity": "sha512-CSR7AO+4AHUeSOnZ/NBNCElDeWfRh9bXtOck27083kc7SznmmHIhNEkEOCQOn0wvrIMjS3IH0TNLR16vuc46mA==",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
       "dependencies": {
-        "multibase": "^4.0.1"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -11084,11 +11022,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/vscode-textmate": {
       "version": "5.4.0",
@@ -13408,11 +13341,6 @@
         }
       }
     },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14345,46 +14273,6 @@
       "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
       "dev": true
     },
-    "cids": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.6.tgz",
-      "integrity": "sha512-5P+Jas2bVpjiHibp/SOwKY+v7JhAjTChaAZN+vCIrsWXn/JZV0frX22Vp5zZgEyJRPco79pX+yNQ2S3LkRukHQ==",
-      "requires": {
-        "multibase": "^4.0.1",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.1",
-        "uint8arrays": "^2.1.3"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-          "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-          "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
-          "requires": {
-            "uint8arrays": "^2.1.3",
-            "varint": "^5.0.2"
-          }
-        },
-        "multihashes": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-          "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^2.1.3",
-            "varint": "^5.0.2"
-          }
-        }
-      }
-    },
     "cjs-module-lexer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
@@ -14615,12 +14503,22 @@
         "elliptic": "^6.5.4",
         "js-sha3": "^0.8.0",
         "uint8arrays": "^2.1.3"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.1.10",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
+          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "did-resolver": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.1.0.tgz",
-      "integrity": "sha512-uf3/4LfHoDn3Ek8bFegO72OemHMytBhAkud6CA1HlB5I0iVwrCpG4oh+DA6DXUuBdhrA0cY4cGz1D0VNDTlgnw=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.1.3.tgz",
+      "integrity": "sha512-ab8y90tSiDkTdfddXRC9Qcb1QSd568aC6+OgFTrcE4rs1vQAZOil+VqXHDu+Ff/UvhxlckPO8oJtp86iICZG0w=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -18980,9 +18878,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -19147,9 +19045,9 @@
       }
     },
     "rpc-utils": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.3.4.tgz",
-      "integrity": "sha512-VmaweXLRpOO2U0FX3Prb88KS0xxkpJK+pJKupR+TagvBmmEetSmvEz+SGTuKwhR9tdSFmjrqt1QSK53Vltapww==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.4.0.tgz",
+      "integrity": "sha512-XBvam3jhcD4d66kFRGjr0cAwJNf8v8eXeJNN187jDGvHuQO9Dugu01WCAghojAbSOcdimCBBz77WNVU1j2+Uig==",
       "requires": {
         "nanoid": "^3.1.21"
       }
@@ -19704,21 +19602,11 @@
       "optional": true
     },
     "uint8arrays": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.5.tgz",
-      "integrity": "sha512-CSR7AO+4AHUeSOnZ/NBNCElDeWfRh9bXtOck27083kc7SznmmHIhNEkEOCQOn0wvrIMjS3IH0TNLR16vuc46mA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
       "requires": {
-        "multibase": "^4.0.1"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-          "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        }
+        "multiformats": "^9.4.2"
       }
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -19788,11 +19676,6 @@
           "dev": true
         }
       }
-    },
-    "varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "vscode-textmate": {
       "version": "5.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^7.28.0",
         "eslint-config-3box": "^0.2.0",
         "jest": "^27.0.4",
+        "jest-resolver-enhanced": "^1.0.1",
         "prettier": "^2.3.1",
         "typedoc": "^0.20.37",
         "typescript": "^4.2.4"
@@ -4414,6 +4415,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -8255,6 +8269,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-resolver-enhanced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-resolver-enhanced/-/jest-resolver-enhanced-1.0.1.tgz",
+      "integrity": "sha512-/lHVgdf+VYeFw+s8e09PJ83UdlJ1wb+D7ppFvh1sva3fdhHgLX+iMfVjMDHeN1HvHuauTkLOx3GI7bUnGppl5Q==",
+      "dev": true,
+      "dependencies": {
+        "enhanced-resolve": "^5.8.2"
+      }
+    },
     "node_modules/jest-runner": {
       "version": "27.0.4",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.4.tgz",
@@ -10714,6 +10737,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/terminal-link": {
       "version": "2.1.1",
@@ -14663,6 +14695,16 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "enhanced-resolve": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      }
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -17572,6 +17614,15 @@
         }
       }
     },
+    "jest-resolver-enhanced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-resolver-enhanced/-/jest-resolver-enhanced-1.0.1.tgz",
+      "integrity": "sha512-/lHVgdf+VYeFw+s8e09PJ83UdlJ1wb+D7ppFvh1sva3fdhHgLX+iMfVjMDHeN1HvHuauTkLOx3GI7bUnGppl5Q==",
+      "dev": true,
+      "requires": {
+        "enhanced-resolve": "^5.8.2"
+      }
+    },
     "jest-runner": {
       "version": "27.0.4",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.4.tgz",
@@ -19480,6 +19531,12 @@
           "dev": true
         }
       }
+    },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true
     },
     "terminal-link": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
   "dependencies": {
     "@stablelib/random": "^1.0.1",
     "cids": "^1.1.6",
-    "dag-jose-utils": "^0.1.1",
+    "dag-jose-utils": "^1.0.0",
     "did-jwt": "^5.6.1",
     "did-resolver": "^3.1.0",
+    "multiformats": "^9.4.10",
+    "query-string": "^7.0.0",
     "rpc-utils": "^0.3.4",
-    "uint8arrays": "^2.1.5",
-    "query-string": "^7.0.0"
+    "uint8arrays": "^2.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -54,11 +54,9 @@
     "eslint": "^7.28.0",
     "eslint-config-3box": "^0.2.0",
     "jest": "^27.0.4",
+    "jest-resolver-enhanced": "^1.0.1",
     "prettier": "^2.3.1",
     "typedoc": "^0.20.37",
     "typescript": "^4.2.4"
-  },
-  "jest": {
-    "testRegex": ".(spec|test).ts$"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,14 +33,13 @@
   "homepage": "https://github.com/ceramicnetwork/js-did#readme",
   "dependencies": {
     "@stablelib/random": "^1.0.1",
-    "cids": "^1.1.6",
     "dag-jose-utils": "^1.0.0",
     "did-jwt": "^5.6.1",
-    "did-resolver": "^3.1.0",
+    "did-resolver": "^3.1.3",
     "multiformats": "^9.4.10",
-    "query-string": "^7.0.0",
-    "rpc-utils": "^0.3.4",
-    "uint8arrays": "^2.1.5"
+    "query-string": "^7.0.1",
+    "rpc-utils": "^0.4.0",
+    "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/src/__tests__/provider-behavior.test.ts
+++ b/src/__tests__/provider-behavior.test.ts
@@ -6,7 +6,6 @@ import { randomBytes } from '@stablelib/random'
 import { generateKeyPairFromSeed } from '@stablelib/x25519'
 import { x25519Decrypter, decryptJWE, JWE } from 'did-jwt'
 import { encodePayload, prepareCleartext, decodeCleartext } from 'dag-jose-utils'
-import crypto from 'crypto'
 
 import * as utils from '../utils'
 // @ts-ignore
@@ -14,7 +13,6 @@ utils.randomString = () => 'rWCXyH1otp5/F78tycckgg'
 const { encodeBase64, encodeBase64Url } = utils
 
 global.Date.now = jest.fn(() => 1606236374000)
-global.crypto = crypto.webcrypto
 
 import { DID } from '../did'
 import { DIDProvider } from '../types'

--- a/src/__tests__/provider-behavior.test.ts
+++ b/src/__tests__/provider-behavior.test.ts
@@ -6,6 +6,7 @@ import { randomBytes } from '@stablelib/random'
 import { generateKeyPairFromSeed } from '@stablelib/x25519'
 import { x25519Decrypter, decryptJWE, JWE } from 'did-jwt'
 import { encodePayload, prepareCleartext, decodeCleartext } from 'dag-jose-utils'
+import crypto from 'crypto'
 
 import * as utils from '../utils'
 // @ts-ignore
@@ -13,6 +14,7 @@ utils.randomString = () => 'rWCXyH1otp5/F78tycckgg'
 const { encodeBase64, encodeBase64Url } = utils
 
 global.Date.now = jest.fn(() => 1606236374000)
+global.crypto = crypto.webcrypto
 
 import { DID } from '../did'
 import { DIDProvider } from '../types'

--- a/src/__tests__/provider-behavior.test.ts
+++ b/src/__tests__/provider-behavior.test.ts
@@ -488,7 +488,8 @@ describe('`decryptDagJWE` method', () => {
 
   test('uses the provider attached to the instance', async () => {
     const clearObj = { asdf: 432 }
-    const cleartext = encodeBase64(prepareCleartext(clearObj))
+    const preparedCleartext = await prepareCleartext(clearObj)
+    const cleartext = encodeBase64(preparedCleartext)
     const provider = {
       send: jest.fn((req: { id: string }) => {
         return Promise.resolve({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type CID from 'cids'
+import { CID } from 'multiformats/cid'
 import type { JWE } from 'did-jwt'
 import type { RPCClient, RPCConnection, RPCRequest, RPCResponse } from 'rpc-utils'
 


### PR DESCRIPTION
# Update cids and dag-jose-utils - #48 

## Description

Update `cids` --> `multiformats/cid`
Update `dag-jose-utils` to latest

`CID.asCID()` is used to convert from different versions of `multiformats/cid`
`ipfs-core` currently used in `js-ceramic` and `ceramic-anchor-service` uses `cids` but `ipfs-core` will be updated shortly to the latest version in these packages which uses `multiformats/cid`

## How Has This Been Tested?

Unit tests still pass
Manual IPFS tests have been done
Note: Older versions of the `ipfs-core` package can still be used. You just have to convert the did CIDS into IPFS cids before using IPFS. 

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties


