### PR TITLE
bump cacao version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/random": "^1.0.1",
-        "ceramic-cacao": "^0.0.11",
+        "ceramic-cacao": "^0.0.12",
         "dag-jose-utils": "^1.0.0",
         "did-jwt": "^5.12.3",
         "did-resolver": "^3.1.5",
@@ -4630,9 +4630,9 @@
       }
     },
     "node_modules/ceramic-cacao": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.11.tgz",
-      "integrity": "sha512-+4h3MRj2gYqgFNZ0yxQ3AnYLuiaEIvrdLKO3BJSztYISMuNWqtXgYHpA9eEDl8nuGUYg13dnRVDsmtS6ydgaEA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.12.tgz",
+      "integrity": "sha512-WplbNqfn19Rqh4KoGJ00AFFiaoDvsXKxoBYapcE+VzRUwHwJVFTyRa/ImX+Go6KCmscJgqz9Tr8Y2Wyu7ZeoiA==",
       "dependencies": {
         "@ethersproject/wallet": "^5.5.0",
         "@ipld/dag-cbor": "^6.0.14",
@@ -15649,9 +15649,9 @@
       "integrity": "sha512-zNgXCO0jlGDKh8EQO34PziChBZhOoLf3qjkS0VtKy4jEKjEX/PbrKYQ1QP+960rxmC3fUuN1yOeq4Frf2E9RTw=="
     },
     "ceramic-cacao": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.11.tgz",
-      "integrity": "sha512-+4h3MRj2gYqgFNZ0yxQ3AnYLuiaEIvrdLKO3BJSztYISMuNWqtXgYHpA9eEDl8nuGUYg13dnRVDsmtS6ydgaEA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.12.tgz",
+      "integrity": "sha512-WplbNqfn19Rqh4KoGJ00AFFiaoDvsXKxoBYapcE+VzRUwHwJVFTyRa/ImX+Go6KCmscJgqz9Tr8Y2Wyu7ZeoiA==",
       "requires": {
         "@ethersproject/wallet": "^5.5.0",
         "@ipld/dag-cbor": "^6.0.14",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/ceramicnetwork/js-did#readme",
   "dependencies": {
     "@stablelib/random": "^1.0.1",
-    "ceramic-cacao": "^0.0.11",
+    "ceramic-cacao": "^0.0.12",
     "dag-jose-utils": "^1.0.0",
     "did-jwt": "^5.12.3",
     "did-resolver": "^3.1.5",


### PR DESCRIPTION
# Bump CACAO version to use browser-compatible APG 

## Description

Product team pointed out that `dids` had a deep dependency on `fs` and `path` due to using `apg` during ABNF parsing. Cacao new version was released which fixed that issue. This version bump updates `dids` to use the latest version of CACAO so it is browser compatible.

## How Has This Been Tested?

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
