### PR TITLE
bump cacao to 0.0.13 to fix import issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/ceramicnetwork/js-did#readme",
   "dependencies": {
     "@stablelib/random": "^1.0.1",
-    "ceramic-cacao": "^0.0.12",
+    "ceramic-cacao": "^0.0.13",
     "dag-jose-utils": "^1.0.0",
     "did-jwt": "^5.12.3",
     "did-resolver": "^3.1.5",


### PR DESCRIPTION
# Bumps CACAO to 0.0.13

## Description

Fixes the file imports to have the `.js` extension included for ESM/CJS resolution

Please see imports in this file: https://github.com/ceramicnetwork/cacao/blob/main/src/abnf.ts

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
