### PR TITLE
Main import should point to module file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0-alpha.6",
   "description": "Typescript library for interacting with DIDs",
   "type": "module",
-  "main": "./lib/index.cjs",
+  "main": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Description

Looks like the package.json setup is invalid, having a `main` file reference as CommonJS while the package is set as `module`.
This notably breaks imports with Jest.

## How Has This Been Tested?

Local change fixes test runner.
