### PR TITLE
fix conditional so it cannot return without an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ethers": "^5.5.2",
     "multiformats": "^9.4.10",
     "query-string": "^7.0.1",
-    "rpc-utils": "^0.6.1",
+    "rpc-utils": "^0.4.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/src/did.ts
+++ b/src/did.ts
@@ -317,11 +317,9 @@ export class DID {
       const controllers = extractControllers(controllerProperty)
 
       if (
-        options.capability &&
-        options.capability.s &&
+        options.capability?.s &&
         options.capability.p.aud === signerDid &&
-        (options.capability.p.iss === options.issuer ||
-          controllers.includes(options.capability.p.iss))
+        controllers.includes(options.capability.p.iss)
       ) {
         Cacao.verify(options.capability, {
           atTime: options.atTime,

--- a/src/did.ts
+++ b/src/did.ts
@@ -316,16 +316,16 @@ export class DID {
       const controllerProperty = issuerResolution.didDocument?.controller
       const controllers = extractControllers(controllerProperty)
 
-      if (options.capability && options.capability.s) {
-        if (
-          (options.capability.p.iss === options.issuer ||
-            controllers.includes(options.capability.p.iss)) &&
-          options.capability.p.aud === signerDid
-        ) {
-          Cacao.verify(options.capability, {
-            atTime: options.atTime,
-          })
-        }
+      if (
+        options.capability &&
+        options.capability.s &&
+        options.capability.p.aud === signerDid &&
+        (options.capability.p.iss === options.issuer ||
+          controllers.includes(options.capability.p.iss))
+      ) {
+        Cacao.verify(options.capability, {
+          atTime: options.atTime,
+        })
       } else {
         const signerIsController = signerDid ? controllers.includes(signerDid) : false
         if (!signerIsController) {


### PR DESCRIPTION
# Fix possible incorrect JWS verification due to nested if without proper else

## Description

Prior to this PR, there existed a nested conditional. If code entered the parent conditional but not the child, there was no else statement to throw an error. This resulted in invalid JWS's being able to be verified, as discovered during CACAO's integration tests. 

This PR fixes that by merging both conditionals into one, so the `else` points to the pre-existing error throw.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] CACAO integration tests

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
