### PR TITLE
Bump cacao version to 0.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/random": "^1.0.1",
-        "ceramic-cacao": "^0.0.13",
+        "ceramic-cacao": "^0.0.14",
         "dag-jose-utils": "^1.0.0",
         "did-jwt": "^5.12.3",
         "did-resolver": "^3.1.5",
@@ -4674,9 +4674,9 @@
       }
     },
     "node_modules/ceramic-cacao": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.13.tgz",
-      "integrity": "sha512-AxLBX1c5fkeK5k4xf7MYX97KnF+pg5c4aPkD9LVLzPvWbHadQmXvh+HJuFjvS/IKPwvuLvbacdMO2eM1Oeb3Kg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.14.tgz",
+      "integrity": "sha512-IieUC7U/Kihb6jUBl/euEIccXwGFK9h4ff9Z+sAUGS3+7tab1KUXvV3P8TrWFpkWD5J6KzL3pXwK4COFyAPy3A==",
       "dependencies": {
         "@ethersproject/wallet": "^5.5.0",
         "@ipld/dag-cbor": "^6.0.14",
@@ -15570,9 +15570,9 @@
       "integrity": "sha512-dOGlTG610S6t3j7EYFxPBH7KiF1OlSAdWtMI4Iv1dabcId/L/nUvkfOEPge+vDp9YoPerEMiDoy5+Vm2oEqmQw=="
     },
     "ceramic-cacao": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.13.tgz",
-      "integrity": "sha512-AxLBX1c5fkeK5k4xf7MYX97KnF+pg5c4aPkD9LVLzPvWbHadQmXvh+HJuFjvS/IKPwvuLvbacdMO2eM1Oeb3Kg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.14.tgz",
+      "integrity": "sha512-IieUC7U/Kihb6jUBl/euEIccXwGFK9h4ff9Z+sAUGS3+7tab1KUXvV3P8TrWFpkWD5J6KzL3pXwK4COFyAPy3A==",
       "requires": {
         "@ethersproject/wallet": "^5.5.0",
         "@ipld/dag-cbor": "^6.0.14",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/ceramicnetwork/js-did#readme",
   "dependencies": {
     "@stablelib/random": "^1.0.1",
-    "ceramic-cacao": "^0.0.13",
+    "ceramic-cacao": "^0.0.14",
     "dag-jose-utils": "^1.0.0",
     "did-jwt": "^5.12.3",
     "did-resolver": "^3.1.5",


### PR DESCRIPTION
# Bumps CACAO version to 0.0.14

## Description

Cacao commit https://github.com/ceramicnetwork/cacao/commit/866872b913dba4a20ff8c02a1ebd3b3a1127af92 updated the cacao data structure to separate the header and signature types. This version bump is to use that version in js-did.

## How Has This Been Tested?

Tests did not change.
