### PR TITLE
[NET-1253] use `Date` instead of `number` for `atTime`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/random": "^1.0.1",
-        "ceramic-cacao": "^0.0.16",
+        "ceramic-cacao": "^0.0.17",
         "dag-jose-utils": "^1.0.0",
         "did-jwt": "^5.12.3",
         "did-resolver": "^3.1.5",
@@ -4255,9 +4255,9 @@
       }
     },
     "node_modules/ceramic-cacao": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.16.tgz",
-      "integrity": "sha512-/+IShB8KiYu3JLAbezd6oq1KKntu0cyfyE6MaJHjP5UOqRjR9pcoEsx9K5zvyDOpLxmta7csM4jcuJuYCcdaiw==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.17.tgz",
+      "integrity": "sha512-g9hwO9feZOeCqmWUuRTq64DZiB4H14nhC6IiIVTzjmC2pxgLNFXNwgUNB0xbnx3+OqtadxJn5lmyDl31c20iBg==",
       "dependencies": {
         "@ethersproject/wallet": "^5.5.0",
         "@ipld/dag-cbor": "^6.0.14",
@@ -12950,9 +12950,9 @@
       "integrity": "sha512-dOGlTG610S6t3j7EYFxPBH7KiF1OlSAdWtMI4Iv1dabcId/L/nUvkfOEPge+vDp9YoPerEMiDoy5+Vm2oEqmQw=="
     },
     "ceramic-cacao": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.16.tgz",
-      "integrity": "sha512-/+IShB8KiYu3JLAbezd6oq1KKntu0cyfyE6MaJHjP5UOqRjR9pcoEsx9K5zvyDOpLxmta7csM4jcuJuYCcdaiw==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/ceramic-cacao/-/ceramic-cacao-0.0.17.tgz",
+      "integrity": "sha512-g9hwO9feZOeCqmWUuRTq64DZiB4H14nhC6IiIVTzjmC2pxgLNFXNwgUNB0xbnx3+OqtadxJn5lmyDl31c20iBg==",
       "requires": {
         "@ethersproject/wallet": "^5.5.0",
         "@ipld/dag-cbor": "^6.0.14",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/ceramicnetwork/js-did#readme",
   "dependencies": {
     "@stablelib/random": "^1.0.1",
-    "ceramic-cacao": "^0.0.16",
+    "ceramic-cacao": "^0.0.17",
     "dag-jose-utils": "^1.0.0",
     "did-jwt": "^5.12.3",
     "did-resolver": "^3.1.5",

--- a/src/__tests__/jws-verification-behavior.test.ts
+++ b/src/__tests__/jws-verification-behavior.test.ts
@@ -193,8 +193,8 @@ describe('atTime', () => {
     did.resolve = fauxResolve
   })
 
-  const beforeRotation = new Date('2021-07-07T08:00:19Z').valueOf()
-  const afterRotation = new Date('2021-07-07T08:40:19Z').valueOf()
+  const beforeRotation = new Date('2021-07-07T08:00:19Z')
+  const afterRotation = new Date('2021-07-07T08:40:19Z')
   const timeKeysRotatedInSec = Math.floor(
     new Date(VERSION_0_ROTATED.didDocumentMetadata.nextUpdate).valueOf() / 1000
   )
@@ -219,7 +219,10 @@ describe('atTime', () => {
     const afterRotationBeforePhaseOut = timeKeysRotatedInSec + revocationPhaseOut - 1
 
     await expect(
-      did.verifyJWS(jwsV0, { atTime: afterRotationBeforePhaseOut * 1000, revocationPhaseOut })
+      did.verifyJWS(jwsV0, {
+        atTime: new Date(afterRotationBeforePhaseOut * 1000),
+        revocationPhaseOut,
+      })
     ).resolves.toBeTruthy()
   })
   test('fail after rotation if not within revocationPhaseOut period', async () => {
@@ -228,7 +231,10 @@ describe('atTime', () => {
     const afterRotationAfterPhaseOut = timeKeysRotatedInSec + revocationPhaseOut
 
     await expect(
-      did.verifyJWS(jwsV0, { atTime: afterRotationAfterPhaseOut * 1000, revocationPhaseOut })
+      did.verifyJWS(jwsV0, {
+        atTime: new Date(afterRotationAfterPhaseOut * 1000),
+        revocationPhaseOut,
+      })
     ).rejects.toThrow(/invalid_jws: signature authored with a revoked DID version/)
   })
 

--- a/src/__tests__/provider-behavior.test.ts
+++ b/src/__tests__/provider-behavior.test.ts
@@ -362,7 +362,7 @@ describe('`createDagJWS method`', () => {
       await did.verifyJWS(res.jws, {
         issuer: `did:pkh:eip155:1:${wallet.address}`,
         capability: cacao,
-        atTime: Math.floor(Date.parse('2021-10-30T16:25:24.000Z') / 1000),
+        atTime: new Date('2021-10-30T16:25:24.000Z'),
       })
     }).not.toThrowError()
 

--- a/src/did.ts
+++ b/src/did.ts
@@ -315,8 +315,7 @@ export class DID {
       signerDid === options.capability.p.aud
     ) {
       Cacao.verify(options.capability, {
-        // CACAO requires `atTime` in seconds
-        atTime: options.atTime ? options.atTime.getTime() / 1000 : undefined,
+        atTime: options.atTime ? options.atTime : undefined,
       })
     } else if (options.issuer && options.issuer !== signerDid) {
       const issuerUrl = didWithTime(options.issuer, options.atTime)
@@ -330,8 +329,7 @@ export class DID {
         controllers.includes(options.capability.p.iss)
       ) {
         Cacao.verify(options.capability, {
-          // CACAO requires `atTime` in seconds
-          atTime: options.atTime ? options.atTime.getTime() / 1000 : undefined,
+          atTime: options.atTime ? options.atTime : undefined,
         })
       } else {
         const signerIsController = signerDid ? controllers.includes(signerDid) : false

--- a/src/did.ts
+++ b/src/did.ts
@@ -43,7 +43,7 @@ export interface VerifyJWSOptions {
   /**
    * JS timestamp when the signature was allegedly made. `undefined` means _now_.
    */
-  atTime?: number
+  atTime?: Date
 
   /**
    * If true, timestamp checking is disabled.
@@ -294,7 +294,7 @@ export class DID {
         // was signed before the revocation happened.
         const phaseOutMS = options.revocationPhaseOut ? options.revocationPhaseOut * 1000 : 0
         const revocationTime = new Date(nextUpdate).valueOf() + phaseOutMS
-        const isEarlier = options.atTime && options.atTime < revocationTime
+        const isEarlier = options.atTime && options.atTime.getTime() < revocationTime
         const isLater = !isEarlier
         if (isLater) {
           // Do not allow using a key _after_ it is being revoked
@@ -303,7 +303,7 @@ export class DID {
       }
       // Key used before `updated` date
       const updated = didResolutionResult.didDocumentMetadata?.updated
-      if (updated && options.atTime && options.atTime < new Date(updated).valueOf()) {
+      if (updated && options.atTime && options.atTime.getTime() < new Date(updated).valueOf()) {
         throw new Error(`invalid_jws: signature authored before creation of DID version: ${kid}`)
       }
     }
@@ -315,7 +315,8 @@ export class DID {
       signerDid === options.capability.p.aud
     ) {
       Cacao.verify(options.capability, {
-        atTime: options.atTime,
+        // CACAO requires `atTime` in seconds
+        atTime: options.atTime ? options.atTime.getTime() / 1000 : undefined,
       })
     } else if (options.issuer && options.issuer !== signerDid) {
       const issuerUrl = didWithTime(options.issuer, options.atTime)
@@ -329,7 +330,8 @@ export class DID {
         controllers.includes(options.capability.p.iss)
       ) {
         Cacao.verify(options.capability, {
-          atTime: options.atTime,
+          // CACAO requires `atTime` in seconds
+          atTime: options.atTime ? options.atTime.getTime() / 1000 : undefined,
         })
       } else {
         const signerIsController = signerDid ? controllers.includes(signerDid) : false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,9 +31,9 @@ export function fromDagJWS(jws: DagJWS): string {
 /**
  * Make DID URL from DID and timestamp (= versionTime query)
  */
-export function didWithTime(did: string, atTime?: number): string {
+export function didWithTime(did: string, atTime?: Date): string {
   if (atTime) {
-    const versionTime = new Date(atTime).toISOString().split('.')[0] + 'Z'
+    const versionTime = atTime.toISOString().split('.')[0] + 'Z'
     return `${did}?versionTime=${versionTime}`
   } else {
     return did


### PR DESCRIPTION
# Change `atTime` argument to use `Date` instead of `number`

## Description

title

## How Has This Been Tested?

Previous tests were modified to conform

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
