### PR TITLE
feat: add parent did option/getter, for improved cacao support in con…

### DIFF
--- a/src/__tests__/provider-behavior.test.ts
+++ b/src/__tests__/provider-behavior.test.ts
@@ -371,6 +371,7 @@ describe('`createDagJWS method`', () => {
 
     expect(did.parent).toBe(`did:pkh:eip155:1:${wallet.address}`)
     expect(did.hasParent).toBe(true)
+    expect(did.hasCapability).toBe(true)
 
     expect(async () => {
       await did.verifyJWS(res.jws, {

--- a/src/__tests__/provider-behavior.test.ts
+++ b/src/__tests__/provider-behavior.test.ts
@@ -86,6 +86,17 @@ test('`id` property', async () => {
   expect(() => did.id).toThrow('DID is not authenticated')
 })
 
+test('`parent` property', async () => {
+  const { DID } = await import('../did.js')
+  const did = new DID(defaultOptions)
+  expect(() => did.parent).toThrow('DID has no parent DID')
+  expect(did.hasParent).toBe(false)
+  const parent = 'did:pkh:eip155:1:0xh...'
+  const didWParent = new DID(Object.assign(defaultOptions, { parent }))
+  expect(didWParent.parent).toBe(parent)
+  expect(didWParent.hasParent).toBe(true)
+})
+
 test('RPC calls throw an error if the response payload is an error', async () => {
   const { DID } = await import('../did.js')
   const provider1 = {
@@ -357,6 +368,9 @@ describe('`createDagJWS method`', () => {
 
     const res = await did.createDagJWS(data)
     const encPayload = await encodePayload(data)
+
+    expect(did.parent).toBe(`did:pkh:eip155:1:${wallet.address}`)
+    expect(did.hasParent).toBe(true)
 
     expect(async () => {
       await did.verifyJWS(res.jws, {

--- a/src/did.ts
+++ b/src/did.ts
@@ -130,13 +130,20 @@ export class DID {
   }
 
   /**
-   * Check if the DID has a capability attached
+   *  Get attached capability
    */
   get capability(): Cacao {
     if (!this._capability) {
       throw new Error('DID has no capability attached')
     }
     return this._capability
+  }
+
+  /**
+   * Check if the DID has a capability attached
+   */
+  get hasCapability(): boolean {
+    return this._capability != null
   }
 
   /**
@@ -157,13 +164,6 @@ export class DID {
   }
 
   /**
-   * Check if user is authenticated.
-   */
-  get authenticated(): boolean {
-    return this._id != null
-  }
-
-  /**
    * Get the DID identifier of the user.
    */
   get id(): string {
@@ -171,6 +171,13 @@ export class DID {
       throw new Error('DID is not authenticated')
     }
     return this._id
+  }
+
+  /**
+   * Check if user is authenticated.
+   */
+  get authenticated(): boolean {
+    return this._id != null
   }
 
   /**


### PR DESCRIPTION
Reference [SIWE+ spec](https://www.notion.so/threebox/CACAO-DID-PKH-SIWE-Client-Libraries-5ce1f1f6e8c7417683c2b63e07f91cef#741885cca9d94532afee11a46621ab7d), allows ceramic to set stream controller to parent, while signing with the did instance. Allows devs to not have to know that implementation detail of cacao and allows glaze/apps libs to use cacao + other dids instances interchangeably.
