### PR TITLE
fixes broken export when using webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./lib/index.js"
-    }
+    ".": "./lib/index.js"
   },
   "files": [
     "lib/*"


### PR DESCRIPTION
I bumped `dids` to version 3.1.0 now running into:
```
Package path . is not exported from package /home/arno/dev/swearby/swearby-web-ext/node_modules/dids (see exports field in /home/arno/dev/swearby/swearby-web-ext/node_modules/dids/package.json)
 @ ./src/popup/index.tsx 59:30-48
```

DID is imported like this:
`import { DID } from "dids";`

I thought it was my webpack config causing issue it...
But finally that commit resolved the issue for me