### PR TITLE
Feat/publish website apps 659

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,39 @@
+name: Deploy docs
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'pnpm'
+
+      - name: Install dependencies and build
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs website
+        run: (cd website && pnpm build)
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 const config = {
   title: 'DIDs',
   tagline: 'Decentralized Identifiers tools',
-  url: 'https://ceramicnetwork.github.io',
-  baseUrl: '/js-did/',
+  url: 'https://dids.js.org',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 const config = {
   title: 'DIDs',
   tagline: 'Decentralized Identifiers tools',
-  url: 'https://dids.js.org',
+  url: 'https://did.js.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,1 +1,1 @@
-dids.js.org
+did.js.org

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+dids.js.org


### PR DESCRIPTION
# Prepare to publish the docusaurus website from `./website`

## Description

Followed similar setup from `js-composedb` and the steps described on https://js.org/ (so that we can publish on https://did.js.org).

My understanding is that the next steps after merging this PR should be:
1. Merge `main` to `gh-pages`
2. Create a PR that adds `did.org.js` to the list of supported cnames, analogous to https://github.com/js-org/js.org/blob/master/cnames_active.js#L550 

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Built and tested the website

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
