### PR TITLE
Don't use 'DIDs' as an umbrella name covering packages in

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -3,6 +3,10 @@ import TabItem from '@theme/TabItem'
 
 # Installation
 
+### did-session
+
+We encourage you to use `did-sessions` to manage all your DID-related needs:
+
 <Tabs
   defaultValue="pnpm"
   groupId="package-manager"
@@ -29,6 +33,41 @@ npm install did-session
 
 ```sh
 yarn add did-session
+```
+
+  </TabItem>
+</Tabs>
+
+### dids
+
+You can also just use `dids`, if you don't want authorization features:
+
+<Tabs
+  defaultValue="pnpm"
+  groupId="package-manager"
+  values={[
+    {label: 'pnpm', value: 'pnpm'},
+    {label: 'npm', value: 'npm'},
+    {label: 'Yarn', value: 'yarn'},
+  ]}>
+  <TabItem value="pnpm">
+
+```sh
+pnpm add dids
+```
+
+  </TabItem>
+  <TabItem value="npm">
+
+```sh
+npm install dids
+```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```sh
+yarn add dids
 ```
 
   </TabItem>

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -1,3 +1,3 @@
-# Welcome to DIDs
+# Welcome to `js-did`
 
-DIDs are composed of a set of packages to interact with and manage DIDs.
+`js-did` is a monorepo of packages that provide APIs to interact with and manage DIDs.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,7 +6,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'DIDs',
+  title: 'js-did',
   tagline: 'Decentralized Identifiers tools',
   url: 'https://did.js.org',
   baseUrl: '/',
@@ -53,7 +53,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       navbar: {
-        title: 'DIDs',
+        title: 'js-did',
         logo: {
           alt: 'Ceramic Logo',
           src: 'img/logo.svg',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -18,7 +18,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/introduction">
-            DIDs Documentation
+             Documentation
           </Link>
         </div>
       </div>


### PR DESCRIPTION
# Don't use 'DIDs' as an umbrella name covering packages in js-dids

## Description

We want the docs to be available ad did.js.org and in general we want to use the 'did' name and in general 'DIDs' seem confusing. I replaced it with just 'js-did' for now. We'll gather more feedback to see, if we want to change this name to something else.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Built and reviewed the docs on this branch


## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
- [X] I have made corresponding changes to the documentation
- [X] The changes have been communicated to interested parties
