### PR TITLE
feat: increase default cacao expiry to one week (from 1 day)

### DIFF
--- a/packages/pkh-ethereum/src/authmethod.ts
+++ b/packages/pkh-ethereum/src/authmethod.ts
@@ -54,7 +54,7 @@ async function createCACAO(
   account: AccountId
 ): Promise<Cacao> {
   const now = new Date()
-  const oneDayLater = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+  const oneWeekLater = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
 
   const siweMessage = new SiweMessage({
     domain: opts.domain,
@@ -64,7 +64,7 @@ async function createCACAO(
     version: VERSION,
     nonce: opts.nonce ?? randomString(10),
     issuedAt: now.toISOString(),
-    expirationTime: opts.expirationTime ?? oneDayLater.toISOString(),
+    expirationTime: opts.expirationTime ?? oneWeekLater.toISOString(),
     chainId: account.chainId.reference,
     resources: opts.resources,
   })

--- a/packages/pkh-solana/src/authmethod.ts
+++ b/packages/pkh-solana/src/authmethod.ts
@@ -91,7 +91,7 @@ async function createCACAO(
   account: AccountId
 ): Promise<Cacao> {
   const now = new Date()
-  const oneDayLater = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+  const oneWeekLater = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
 
   const siwsMessage = new SiwsMessage({
     domain: opts.domain,
@@ -101,7 +101,7 @@ async function createCACAO(
     version: VERSION,
     nonce: opts.nonce ?? randomString(10),
     issuedAt: now.toISOString(),
-    expirationTime: opts.expirationTime ?? oneDayLater.toISOString(),
+    expirationTime: opts.expirationTime ?? oneWeekLater.toISOString(),
     chainId: account.chainId.reference,
     resources: opts.resources,
   })


### PR DESCRIPTION
This PR increases the default cacao expiry when used with authmethods in did-session from 1 day to 7 days. We still have the 1 day revocation phaseout, effectively making it 8 days. Expiry is just a client default, not in the cacao library or enforced in anyways, clients may already configure their own but expect most rely on default. Default phaseout is more likely be recognized, as few would change that config value. 

We can discuss the time interval we want to use here. Also how we want to version the release. 