### PR TITLE
fix: normalize checksum address eth

### DIFF
--- a/packages/pkh-ethereum/src/utils.ts
+++ b/packages/pkh-ethereum/src/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable  @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument */
 // TODO types
+import { AccountId } from 'caip'
 
 export function safeSend(provider: any, method: string, params?: Array<any>): Promise<any> {
   if (params == null) {
@@ -44,4 +45,11 @@ export function encodeRpcMessage(method: string, params?: any): any {
     method,
     params,
   }
+}
+
+export function normalizeAccountId(input: AccountId): AccountId {
+  return new AccountId({
+    address: input.address.toLowerCase(),
+    chainId: input.chainId,
+  })
 }


### PR DESCRIPTION
Checksum (mixed case) addresses in eth auth where no longer normalized in switch to did-session. The effect is more minimal here than for caip10 links, and less likely to come up, as it would require the same account to use to two different wallets/providers, which is unlikely (two returning diff format addresses, same wallets either case would not throw an error). It would/will be more problematic for general queries/relations. 

This adds normalization for eth address and is technically a breaking change, and existing checksum address providers that did work fine, will now break, no longer allow content to be added to those streams. It should be few to none returning this, but should try to capture before merging (PR in draft for now)
