### PR TITLE
fix: eth personal sign hex message

### DIFF
--- a/packages/pkh-ethereum/package.json
+++ b/packages/pkh-ethereum/package.json
@@ -50,6 +50,7 @@
     "@didtools/cacao": "workspace:^2.0.0",
     "@ethersproject/wallet": "^5.7.0",
     "@stablelib/random": "^1.0.2",
-    "caip": "^1.1.0"
+    "caip": "^1.1.0",
+    "uint8arrays": "^4.0.3"
   }
 }

--- a/packages/pkh-ethereum/src/authmethod.ts
+++ b/packages/pkh-ethereum/src/authmethod.ts
@@ -2,6 +2,7 @@ import { Cacao, SiweMessage, AuthMethod, AuthMethodOpts } from '@didtools/cacao'
 import { randomString } from '@stablelib/random'
 import { AccountId } from 'caip'
 import { safeSend, normalizeAccountId } from './utils.js'
+import * as u8a from 'uint8arrays'
 
 /**
  * SIWX Version
@@ -11,6 +12,10 @@ export const VERSION = '1'
  * CAIP2 for ethereum, used in CAIP10 (acountId)
  */
 export const CHAIN_NAMESPACE = 'eip155'
+
+function encodeHexStr(str: string): string {
+  return `0x${u8a.toString(u8a.fromString(str, 'utf8'), 'base16')}`
+}
 
 export namespace EthereumWebAuth {
   /**
@@ -70,7 +75,7 @@ async function createCACAO(
     resources: opts.resources,
   })
   const signature = await safeSend(ethProvider, 'personal_sign', [
-    siweMessage.signMessage(),
+    encodeHexStr(siweMessage.signMessage()),
     normAccount.address,
   ])
   siweMessage.signature = signature

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,11 +254,13 @@ importers:
       '@stablelib/random': ^1.0.2
       caip: ^1.1.0
       typescript: ^4.9.5
+      uint8arrays: ^4.0.3
     dependencies:
       '@didtools/cacao': link:../cacao
       '@ethersproject/wallet': 5.7.0
       '@stablelib/random': 1.0.2
       caip: 1.1.0
+      uint8arrays: 4.0.3
     devDependencies:
       typescript: 4.9.5
 


### PR DESCRIPTION
personal_sign spec expects a hex encoded utf8 message, most providers do seem to support both hex & utf8 strings (ie metamask provider and we havent had any other reported errors from common providers), plus most libraries (ethers, web3) accept both and encode as hex before making provider call 

this will provide better general support, esp any other providers that may just follow spec 

This will resolve issue - https://github.com/ceramicnetwork/js-did/issues/131