### PR TITLE
Sorted rows by OS; Added samples for Android10/OS-Authenticator

### DIFF
--- a/packages/key-webauthn/README.md
+++ b/packages/key-webauthn/README.md
@@ -97,24 +97,27 @@ const authMethod = WebauthnAuth.getAuthMethod({ selectDIDs })
 
 Tests done via [demo](https://didtoolswn.surge.sh/).
 
-| Browser       | Version | OS             | Device  | Authenticator      | Works | Remark     |
-|---------------|---------|----------------|---------|--------------------|-------|------------|
-| Chrome        | 116     | Linux          | Desktop | Yubikey v5         | ✅    |            |
-| Firefox       | 115     | Linux          | Desktop | Yubikey v5         | ✅    |            |
-| Chrome        | 107     | Mac OS 10.15.7 | Desktop | Yubikey v5 (USB-C) | ✅    |            |
-| Safari        | 15.6    | Mac OS 10.15.7 | Desktop | Yubikey v5 (USB-C) | ✅    |            |
-| Safari        | 15.6    | Mac OS 10.15.7 | Desktop | OS-Authenticator   | ✅    |            |
-| Mobile Safari | 16.6    | iOS 16.6       | Mobile  | Yubikey v5 (USB-C) | ✅    |            |
-| Mobile Safari | 16.6    | iOS 16.6       | Mobile  | OS-Authenticator   | ✅    |            |
-| Brave         | 119     | Mac OS 10.15.7 | Desktop | 1password          | ✅    |            |
-| Chrome        | 122     | Windows 10     | Desktop | Yubikey v5         | ✅    |            |
-| Chrome        | 122     | Windows 10     | Desktop | GPM+Android device | ❌    | Timeout    |
-| Firefox       | 84      | Windows 10     | Desktop | Yubikey v5         | ❌    | e1         |
-| Firefox       | 120     | Windows 10     | Desktop | Yubikey v5         | ✅    |            |
-| Chrome        | 120     | Android 10     | mobile  | Yubikey v5         | ✅    | OTG/no-NFC |
-| Firefox       | 114     | Android 10     | mobile  | Yubikey v5         | ✅    | OTG/no-NFC |
+| Browser       | Version | OS             | Device  | Authenticator      | Works | Remark  |
+|---------------|---------|----------------|---------|--------------------|-------|---------|
+| Chrome        | 107     | Mac OS 10.15.7 | Desktop | Yubikey v5 (USB-C) | ✅    |         |
+| Safari        | 15.6    | Mac OS 10.15.7 | Desktop | Yubikey v5 (USB-C) | ✅    |         |
+| Safari        | 15.6    | Mac OS 10.15.7 | Desktop | OS-Authenticator   | ✅    |         |
+| Brave         | 119     | Mac OS 10.15.7 | Desktop | 1password          | ✅    |         |
+| Mobile Safari | 16.6    | iOS 16.6       | Mobile  | Yubikey v5 (USB-C) | ✅    |         |
+| Mobile Safari | 16.6    | iOS 16.6       | Mobile  | OS-Authenticator   | ✅    |         |
+| Chrome        | 122     | Windows 10     | Desktop | Yubikey v5         | ✅    |         |
+| Chrome        | 122     | Windows 10     | Desktop | GPM+Android device | ❌    | Timeout |
+| Firefox       | 84      | Windows 10     | Desktop | Yubikey v5         | ❌    | e1      |
+| Firefox       | 120     | Windows 10     | Desktop | Yubikey v5         | ✅    |         |
+| Chrome        | 116     | Linux          | Desktop | Yubikey v5         | ✅    |         |
+| Firefox       | 115     | Linux          | Desktop | Yubikey v5         | ✅    |         |
+| Chrome        | 120     | Android 10     | Mobile  | Yubikey v5         | ✅    | e2      |
+| Chrome        | 120     | Android 10     | Mobile  | OS-Authenticator   | ✅    |         |
+| Firefox       | 114     | Android 10     | Mobile  | Yubikey v5         | ✅    | e2      |
+| Firefox       | 114     | Android 10     | Mobile  | OS-Authenticator   | ✅    |         |
 
-`e1` - An attempt was made to use an object that is not, or is no longer available
+`e1` - An attempt was made to use an object that is not, or is no longer available  
+`e2` - OTG cable was used, when attempting NFC an error message was shown urging USB connection.  
 
 
 ## License


### PR DESCRIPTION
# Updated key-webauthn compatibility table

## Description
Last minute commit that didn't make it into: [PR-175](https://github.com/ceramicnetwork/js-did/pull/175)

Changes done to `README.md`:

- Sorted samples by Operative System
- Added Android 10 / OS-Authenticator results for Firefox & Chrome

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

## References:

https://github.com/ceramicnetwork/js-did/pull/175
