### PR TITLE
chore: release for multiformats 13

### DIFF
--- a/packages/cacao/CHANGELOG.md
+++ b/packages/cacao/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @didtools/cacao
 
+## 3.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - @didtools/codecs@2.0.0
+  - @didtools/siwx@2.0.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/cacao/package.json
+++ b/packages/cacao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/cacao",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Typescript library for Ceramic OCAP",
   "author": "Haardik <hhaardik@uwaterloo.ca>",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/codecs",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",

--- a/packages/did-session/CHANGELOG.md
+++ b/packages/did-session/CHANGELOG.md
@@ -1,0 +1,15 @@
+# did-session
+
+## 3.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - key-did-provider-ed25519@4.0.0
+  - key-did-resolver@4.0.0
+  - dids@5.0.0
+  - @didtools/key-webcrypto@0.2.0

--- a/packages/did-session/package.json
+++ b/packages/did-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-session",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "Manage user DIDs in a web environment",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/dids/CHANGELOG.md
+++ b/packages/dids/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## v2.4.0 (2021-07-12)
 
+## 5.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - @didtools/codecs@2.0.0
+  - @didtools/cacao@3.0.0
+  - @didtools/pkh-ethereum@0.5.0
+
 ## 4.0.4
 
 ### Patch Changes

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dids",
-  "version": "4.0.4",
+  "version": "5.0.0",
   "description": "Typescript library for interacting with DIDs",
   "author": "Joel Thorstensson <oed@3box.io>",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/jest-environment-ceramic/CHANGELOG.md
+++ b/packages/jest-environment-ceramic/CHANGELOG.md
@@ -1,0 +1,7 @@
+# jest-environment-ceramic
+
+## 0.18.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted

--- a/packages/jest-environment-ceramic/package.json
+++ b/packages/jest-environment-ceramic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-ceramic",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Ceramic environment for Jest",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/key-did-provider-ed25519/CHANGELOG.md
+++ b/packages/key-did-provider-ed25519/CHANGELOG.md
@@ -1,5 +1,16 @@
 # key-did-provider-ed25519
 
+## 4.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - dids@5.0.0
+
 ## 3.0.2
 
 ### Patch Changes

--- a/packages/key-did-provider-ed25519/package.json
+++ b/packages/key-did-provider-ed25519/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-did-provider-ed25519",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "author": "Joel Thorstensson",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",

--- a/packages/key-did-provider-secp256k1/CHANGELOG.md
+++ b/packages/key-did-provider-secp256k1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @didtools/key-secp256k1
+
+## 0.3.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - dids@5.0.0

--- a/packages/key-did-provider-secp256k1/package.json
+++ b/packages/key-did-provider-secp256k1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/key-secp256k1",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Joel Thorstensson",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",

--- a/packages/key-did-provider-webcrypto/CHANGELOG.md
+++ b/packages/key-did-provider-webcrypto/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @didtools/key-webcrypto
+
+## 0.2.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted

--- a/packages/key-did-provider-webcrypto/package.json
+++ b/packages/key-did-provider-webcrypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/key-webcrypto",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Joel Thorstensson",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/varint": "^6.0.3",
     "did-jwt": "^7.4.5",
-    "dids": "workspace:^4.0.1",
+    "dids": "workspace:^5.0.0",
     "jest-environment-jsdom": "^29.7.0"
   },
   "dependencies": {

--- a/packages/key-did-resolver/CHANGELOG.md
+++ b/packages/key-did-resolver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 4.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
@@ -7,634 +13,329 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.1.3-rc.0](/compare/key-did-resolver@2.1.2...key-did-resolver@2.1.3-rc.0) (2022-09-28)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [2.1.2](/compare/key-did-resolver@2.1.2-rc.0...key-did-resolver@2.1.2) (2022-09-21)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.1.2-rc.0](/compare/key-did-resolver@2.1.1...key-did-resolver@2.1.2-rc.0) (2022-09-13)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [2.1.1](/compare/key-did-resolver@2.1.1-rc.0...key-did-resolver@2.1.1) (2022-09-08)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.1.1-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.1.0...key-did-resolver@2.1.1-rc.0) (2022-08-22)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 # [2.1.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.1.0-rc.0...key-did-resolver@2.1.0) (2022-08-22)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [2.1.0-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.6...key-did-resolver@2.1.0-rc.0) (2022-08-10)
-
 
 ### Features
 
-* **key-did-resolver:** Use upstream bigint-mod-arith package ([#2355](https://github.com/ceramicnetwork/js-ceramic/issues/2355)) ([b0cfa9c](https://github.com/ceramicnetwork/js-ceramic/commit/b0cfa9cd5b3700de98d7cc5bb458ace0eae824d4))
-
-
-
-
+- **key-did-resolver:** Use upstream bigint-mod-arith package ([#2355](https://github.com/ceramicnetwork/js-ceramic/issues/2355)) ([b0cfa9c](https://github.com/ceramicnetwork/js-ceramic/commit/b0cfa9cd5b3700de98d7cc5bb458ace0eae824d4))
 
 ## [2.0.6](/compare/key-did-resolver@2.0.6-rc.0...key-did-resolver@2.0.6) (2022-08-08)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.0.6-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.5...key-did-resolver@2.0.6-rc.0) (2022-07-06)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [2.0.5](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.5-rc.0...key-did-resolver@2.0.5) (2022-07-06)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.0.5-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.4...key-did-resolver@2.0.5-rc.0) (2022-06-30)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [2.0.4](/compare/key-did-resolver@2.0.4-rc.1...key-did-resolver@2.0.4) (2022-05-18)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.0.4-rc.1](/compare/key-did-resolver@2.0.3...key-did-resolver@2.0.4-rc.1) (2022-05-18)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [2.0.3](/compare/key-did-resolver@2.0.2...key-did-resolver@2.0.3) (2022-05-18)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [2.0.2](/compare/key-did-resolver@2.0.1-rc.1...key-did-resolver@2.0.2) (2022-05-18)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [2.0.1-rc.1](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.0...key-did-resolver@2.0.1-rc.1) (2022-05-12)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## 2.0.1-rc.0 (2022-05-12)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 # [2.0.0](/compare/key-did-resolver@2.0.0-rc.1...key-did-resolver@2.0.0) (2022-04-19)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [2.0.0-rc.1](/compare/key-did-resolver@2.0.0-rc.0...key-did-resolver@2.0.0-rc.1) (2022-04-19)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 # 2.0.0-rc.0 (2022-03-31)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [2.0.0-alpha.4](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.0-alpha.3...key-did-resolver@2.0.0-alpha.4) (2022-03-24)
-
 
 ### Features
 
-* Do not depend on bigint-mod-arith ([#2074](https://github.com/ceramicnetwork/js-ceramic/issues/2074)) ([ad731cd](https://github.com/ceramicnetwork/js-ceramic/commit/ad731cd875ba4c1d9f398e4dc8be843ee4810862))
-* polyfill AbortController, so that Ceramic node works on Node.js v14 ([#2090](https://github.com/ceramicnetwork/js-ceramic/issues/2090)) ([fff3e8a](https://github.com/ceramicnetwork/js-ceramic/commit/fff3e8a18ef7d2ba86c80743f61f0487dae3e129))
-
-
-
-
+- Do not depend on bigint-mod-arith ([#2074](https://github.com/ceramicnetwork/js-ceramic/issues/2074)) ([ad731cd](https://github.com/ceramicnetwork/js-ceramic/commit/ad731cd875ba4c1d9f398e4dc8be843ee4810862))
+- polyfill AbortController, so that Ceramic node works on Node.js v14 ([#2090](https://github.com/ceramicnetwork/js-ceramic/issues/2090)) ([fff3e8a](https://github.com/ceramicnetwork/js-ceramic/commit/fff3e8a18ef7d2ba86c80743f61f0487dae3e129))
 
 # [2.0.0-alpha.3](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.0-alpha.2...key-did-resolver@2.0.0-alpha.3) (2022-03-03)
 
-
 ### Features
 
-* Transition remaining tests to pure ESM ([#2044](https://github.com/ceramicnetwork/js-ceramic/issues/2044)) ([0848eb5](https://github.com/ceramicnetwork/js-ceramic/commit/0848eb59741a2b940de9dd76df94bd8948bae637))
-
-
-
-
+- Transition remaining tests to pure ESM ([#2044](https://github.com/ceramicnetwork/js-ceramic/issues/2044)) ([0848eb5](https://github.com/ceramicnetwork/js-ceramic/commit/0848eb59741a2b940de9dd76df94bd8948bae637))
 
 # [2.0.0-alpha.2](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@2.0.0-alpha.1...key-did-resolver@2.0.0-alpha.2) (2022-02-10)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [2.0.0-alpha.1](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.0...key-did-resolver@2.0.0-alpha.1) (2022-01-14)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 # [2.0.0-alpha.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.0...key-did-resolver@2.0.0-alpha.0) (2021-12-07)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.4.5-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.4...key-did-resolver@1.4.5-rc.0) (2022-01-12)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [1.4.4](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.3...key-did-resolver@1.4.4) (2022-01-12)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.4.3](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.0...key-did-resolver@1.4.3) (2022-01-09)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [1.4.2](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.0...key-did-resolver@1.4.2) (2022-01-09)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.4.1](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.0...key-did-resolver@1.4.1) (2022-01-09)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
-
 
 # [1.4.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.4.0-rc.0...key-did-resolver@1.4.0) (2021-08-25)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [1.4.0-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.3.2-rc.5...key-did-resolver@1.4.0-rc.0) (2021-08-24)
-
 
 ### Features
 
-* named exports ([884a6d8](https://github.com/ceramicnetwork/js-ceramic/commit/884a6d8e490f1c2c99ed99a17e9fd8c3dfb132d2))
-
-
-
-
+- named exports ([884a6d8](https://github.com/ceramicnetwork/js-ceramic/commit/884a6d8e490f1c2c99ed99a17e9fd8c3dfb132d2))
 
 ## [1.3.2-rc.5](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.3.2-rc.4...key-did-resolver@1.3.2-rc.5) (2021-08-23)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## 1.3.2-rc.4 (2021-08-23)
-
 
 ### Bug Fixes
 
-* **ci:** remove private flag ([9974009](https://github.com/ceramicnetwork/js-ceramic/commit/9974009be69382f2a2caf59f4ff72bf6aa12491b))
-
-
-
-
+- **ci:** remove private flag ([9974009](https://github.com/ceramicnetwork/js-ceramic/commit/9974009be69382f2a2caf59f4ff72bf6aa12491b))
 
 ## [1.3.2-rc.3](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.3.2-rc.2...key-did-resolver@1.3.2-rc.3) (2021-08-22)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.3.2-rc.2](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@1.3.2-rc.1...key-did-resolver@1.3.2-rc.2) (2021-08-22)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## 1.3.2-rc.1 (2021-08-22)
-
 
 ### Bug Fixes
 
-* **ci:** remove flag from npm ci cmd ([b8ca310](https://github.com/ceramicnetwork/js-ceramic/commit/b8ca3102963096626a46a3c78c705da26e977021))
-
-
-
-
+- **ci:** remove flag from npm ci cmd ([b8ca310](https://github.com/ceramicnetwork/js-ceramic/commit/b8ca3102963096626a46a3c78c705da26e977021))
 
 ## [1.3.2-rc.0](/compare/key-did-resolver@1.3.1...key-did-resolver@1.3.2-rc.0) (2021-08-13)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.3.1](/compare/key-did-resolver@1.3.0-rc.0...key-did-resolver@1.3.1) (2021-08-11)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 # [1.3.0](/compare/key-did-resolver@1.3.0-rc.0...key-did-resolver@1.3.0) (2021-08-11)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [1.3.0-rc.0](/compare/key-did-resolver@1.2.1...key-did-resolver@1.3.0-rc.0) (2021-07-16)
-
 
 ### Features
 
-* Pass issuer to verifyJWS (#1542) 3c60b0c, closes #1542
-
+- Pass issuer to verifyJWS (#1542) 3c60b0c, closes #1542
 
 ### Reverts
 
-* Revert "Merge secp256r1 key-did-method with npm run docs working (#1418)" (#1440) 8f45f82, closes #1418 #1440
-
-
-
-
+- Revert "Merge secp256r1 key-did-method with npm run docs working (#1418)" (#1440) 8f45f82, closes #1418 #1440
 
 ## [1.2.1](/compare/key-did-resolver@1.2.0...key-did-resolver@1.2.1) (2021-05-25)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [1.2.0](/compare/key-did-resolver@1.2.0-rc.0...key-did-resolver@1.2.0) (2021-05-06)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [1.2.0-rc.0](/compare/key-did-resolver@1.1.2-rc.3...key-did-resolver@1.2.0-rc.0) (2021-04-28)
-
 
 ### Features
 
-* **key-did-resolver:** Bump key-did-resolver RC version 3ac9f0e
-
-
-
-
+- **key-did-resolver:** Bump key-did-resolver RC version 3ac9f0e
 
 ## [1.1.2-rc.3](/compare/key-did-resolver@1.1.2-rc.2...key-did-resolver@1.1.2-rc.3) (2021-04-20)
 
-
 ### Bug Fixes
 
-* Fix tests by using node environment for jest (#1212) 0f04006, closes #1212
-
-
-
-
+- Fix tests by using node environment for jest (#1212) 0f04006, closes #1212
 
 ## [1.1.2-rc.2](/compare/key-did-resolver@1.1.1...key-did-resolver@1.1.2-rc.2) (2021-04-19)
 
-
 ### Bug Fixes
 
-* Fix tests by using node environment for jest (#1212) aff01c6, closes #1212
-
-
-
-
+- Fix tests by using node environment for jest (#1212) aff01c6, closes #1212
 
 ## [1.1.2-rc.1](/compare/key-did-resolver@1.1.1...key-did-resolver@1.1.2-rc.1) (2021-04-15)
 
-
 ### Bug Fixes
 
-* Fix tests by using node environment for jest (#1212) 14309e5, closes #1212
-
-
-
-
+- Fix tests by using node environment for jest (#1212) 14309e5, closes #1212
 
 ## [1.1.2-rc.0](/compare/key-did-resolver@1.1.1...key-did-resolver@1.1.2-rc.0) (2021-04-15)
 
-
 ### Bug Fixes
 
-* Fix tests by using node environment for jest (#1212) aff01c6, closes #1212
-
-
-
-
+- Fix tests by using node environment for jest (#1212) aff01c6, closes #1212
 
 ## [1.1.1](/compare/key-did-resolver@1.1.0...key-did-resolver@1.1.1) (2021-04-02)
 
-
 ### Bug Fixes
 
-* **common, logger:** Clean up dependencies (#1164) 191ad31, closes #1164
-
-
-
-
+- **common, logger:** Clean up dependencies (#1164) 191ad31, closes #1164
 
 ## [1.1.1-rc.3](/compare/key-did-resolver@1.1.0...key-did-resolver@1.1.1-rc.3) (2021-03-26)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.1.1-rc.2](/compare/key-did-resolver@1.1.0...key-did-resolver@1.1.1-rc.2) (2021-03-26)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 ## [1.1.1-rc.1](/compare/key-did-resolver@1.1.0...key-did-resolver@1.1.1-rc.1) (2021-03-26)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [1.1.1-rc.0](/compare/key-did-resolver@1.1.0...key-did-resolver@1.1.1-rc.0) (2021-03-25)
 
 **Note:** Version bump only for package key-did-resolver
-
-
-
-
 
 # [1.1.0](/compare/key-did-resolver@1.1.0-rc.0...key-did-resolver@1.1.0) (2021-03-22)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 # [1.1.0-rc.0](/compare/key-did-resolver@0.2.5...key-did-resolver@1.1.0-rc.0) (2021-03-12)
-
 
 ### Features
 
-* upgrade 3id did resolver (#1108) 24ef6d4, closes #1108
-
-
-
-
+- upgrade 3id did resolver (#1108) 24ef6d4, closes #1108
 
 ## [0.2.5](/compare/key-did-resolver@0.2.5-rc.0...key-did-resolver@0.2.5) (2021-02-04)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [0.2.5-rc.0](/compare/key-did-resolver@0.2.4...key-did-resolver@0.2.5-rc.0) (2021-01-29)
 
 **Note:** Version bump only for package key-did-resolver
 
-
-
-
-
 ## [0.2.4](https://github.com/ceramicnetwork/js-ceramic/compare/key-did-resolver@0.2.3...key-did-resolver@0.2.4) (2020-12-29)
-
 
 ### Bug Fixes
 
-* **http-client:** reload cached documents ([#719](https://github.com/ceramicnetwork/js-ceramic/issues/719)) ([6bc7dbf](https://github.com/ceramicnetwork/js-ceramic/commit/6bc7dbff31eaccfdbcb960effd850f069eb0d538))
-
-
-
-
+- **http-client:** reload cached documents ([#719](https://github.com/ceramicnetwork/js-ceramic/issues/719)) ([6bc7dbf](https://github.com/ceramicnetwork/js-ceramic/commit/6bc7dbff31eaccfdbcb960effd850f069eb0d538))
 
 ## [0.2.3](/compare/key-did-resolver@0.3.0...key-did-resolver@0.2.3) (2020-12-23)
 
-
 ### Reverts
 
-* Revert "chore(release):" 26ed474
-
-
-
-
+- Revert "chore(release):" 26ed474
 
 ## [0.2.2](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.2.2-alpha.0...@ceramicnetwork/key-did-resolver@0.2.2) (2020-12-17)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
 
-
-
-
-
 ## [0.2.2-alpha.0](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.2.1...@ceramicnetwork/key-did-resolver@0.2.2-alpha.0) (2020-12-14)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
-
-
-
-
 
 ## [0.2.1](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.2.0...@ceramicnetwork/key-did-resolver@0.2.1) (2020-12-08)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
 
-
-
-
-
 # [0.2.0](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.3...@ceramicnetwork/key-did-resolver@0.2.0) (2020-11-24)
-
 
 ### Features
 
-* **key-did-resolver:** add support for ed25519 ([#479](https://github.com/ceramicnetwork/js-ceramic/issues/479)) ([23392f5](https://github.com/ceramicnetwork/js-ceramic/commit/23392f5d4a3d3f8ac665f1ed626b8ac1f62cba41))
-
-
-
-
+- **key-did-resolver:** add support for ed25519 ([#479](https://github.com/ceramicnetwork/js-ceramic/issues/479)) ([23392f5](https://github.com/ceramicnetwork/js-ceramic/commit/23392f5d4a3d3f8ac665f1ed626b8ac1f62cba41))
 
 ## [0.1.3](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.3-alpha.0...@ceramicnetwork/key-did-resolver@0.1.3) (2020-11-20)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
 
-
-
-
-
 ## [0.1.3-alpha.0](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.2...@ceramicnetwork/key-did-resolver@0.1.3-alpha.0) (2020-11-20)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
-
-
-
-
 
 ## [0.1.2](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.2-alpha.0...@ceramicnetwork/key-did-resolver@0.1.2) (2020-10-13)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
 
-
-
-
-
 ## [0.1.2-alpha.0](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.1...@ceramicnetwork/key-did-resolver@0.1.2-alpha.0) (2020-10-13)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
-
-
-
-
 
 ## [0.1.1](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.1-alpha.0...@ceramicnetwork/key-did-resolver@0.1.1) (2020-10-05)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
 
-
-
-
-
 ## [0.1.1-alpha.0](https://github.com/ceramicnetwork/js-ceramic/compare/@ceramicnetwork/key-did-resolver@0.1.0...@ceramicnetwork/key-did-resolver@0.1.1-alpha.0) (2020-10-05)
 
 **Note:** Version bump only for package @ceramicnetwork/key-did-resolver
 
-
-
-
-
 # 0.1.0 (2020-09-25)
-
 
 ### Features
 
-* implement initial key-did-resolver module ([#321](https://github.com/ceramicnetwork/js-ceramic/issues/321)) ([472283f](https://github.com/ceramicnetwork/js-ceramic/commit/472283f8419dd51c4725b77083df43abeb9ee387))
-
-
-
-
+- implement initial key-did-resolver module ([#321](https://github.com/ceramicnetwork/js-ceramic/issues/321)) ([472283f](https://github.com/ceramicnetwork/js-ceramic/commit/472283f8419dd51c4725b77083df43abeb9ee387))
 
 # 0.1.0-alpha.0 (2020-09-25)
 
-
 ### Features
 
-* implement initial key-did-resolver module ([#321](https://github.com/ceramicnetwork/js-ceramic/issues/321)) ([472283f](https://github.com/ceramicnetwork/js-ceramic/commit/472283f8419dd51c4725b77083df43abeb9ee387))
+- implement initial key-did-resolver module ([#321](https://github.com/ceramicnetwork/js-ceramic/issues/321)) ([472283f](https://github.com/ceramicnetwork/js-ceramic/commit/472283f8419dd51c4725b77083df43abeb9ee387))

--- a/packages/key-did-resolver/package.json
+++ b/packages/key-did-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-did-resolver",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Ceramic did:key method resolver",
   "keywords": [
     "ceramic",

--- a/packages/key-webauthn/CHANGELOG.md
+++ b/packages/key-webauthn/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @didtools/codecs
+# @didtools/key-webauthn
 
 ## 2.0.0
 
@@ -6,8 +6,7 @@
 
 - Upgrade to multiformats 13 and related packages impacted
 
-## 1.0.1
-
 ### Patch Changes
 
-- Add new codecs package
+- Updated dependencies
+  - @didtools/cacao@3.0.0

--- a/packages/key-webauthn/package.json
+++ b/packages/key-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/key-webauthn",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",

--- a/packages/multidid/CHANGELOG.md
+++ b/packages/multidid/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @didtools/multidid
+
+## 0.1.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted

--- a/packages/multidid/package.json
+++ b/packages/multidid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/multidid",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",

--- a/packages/pkh-did-resolver/CHANGELOG.md
+++ b/packages/pkh-did-resolver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
@@ -7,324 +13,164 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.10-rc.0](/compare/pkh-did-resolver@1.0.9...pkh-did-resolver@1.0.10-rc.0) (2022-09-28)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.9](/compare/pkh-did-resolver@1.0.9-rc.0...pkh-did-resolver@1.0.9) (2022-09-21)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.9-rc.0](/compare/pkh-did-resolver@1.0.8...pkh-did-resolver@1.0.9-rc.0) (2022-09-13)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.8](/compare/pkh-did-resolver@1.0.8-rc.0...pkh-did-resolver@1.0.8) (2022-09-08)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.8-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.7...pkh-did-resolver@1.0.8-rc.0) (2022-08-22)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.7](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.7-rc.0...pkh-did-resolver@1.0.7) (2022-08-22)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.7-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.6...pkh-did-resolver@1.0.7-rc.0) (2022-08-10)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.6](/compare/pkh-did-resolver@1.0.6-rc.0...pkh-did-resolver@1.0.6) (2022-08-08)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.6-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.5...pkh-did-resolver@1.0.6-rc.0) (2022-07-06)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.5](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.5-rc.0...pkh-did-resolver@1.0.5) (2022-07-06)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.5-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.4...pkh-did-resolver@1.0.5-rc.0) (2022-06-30)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.4](/compare/pkh-did-resolver@1.0.4-rc.1...pkh-did-resolver@1.0.4) (2022-05-18)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.4-rc.1](/compare/pkh-did-resolver@1.0.3...pkh-did-resolver@1.0.4-rc.1) (2022-05-18)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.3](/compare/pkh-did-resolver@1.0.2...pkh-did-resolver@1.0.3) (2022-05-18)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [1.0.2](/compare/pkh-did-resolver@1.0.1-rc.2...pkh-did-resolver@1.0.2) (2022-05-18)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [1.0.1-rc.2](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.1-rc.0...pkh-did-resolver@1.0.1-rc.2) (2022-05-12)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## 1.0.1-rc.1 (2022-05-12)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## 1.0.1-rc.0 (2022-04-27)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 # [1.0.0](/compare/pkh-did-resolver@1.0.0-rc.1...pkh-did-resolver@1.0.0) (2022-04-19)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 # [1.0.0-rc.1](/compare/pkh-did-resolver@1.0.0-rc.0...pkh-did-resolver@1.0.0-rc.1) (2022-04-19)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 # 1.0.0-rc.0 (2022-03-31)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 # [1.0.0-alpha.3](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.0-alpha.2...pkh-did-resolver@1.0.0-alpha.3) (2022-03-03)
-
 
 ### Features
 
-* Transition remaining tests to pure ESM ([#2044](https://github.com/ceramicnetwork/js-ceramic/issues/2044)) ([0848eb5](https://github.com/ceramicnetwork/js-ceramic/commit/0848eb59741a2b940de9dd76df94bd8948bae637))
-
-
-
-
+- Transition remaining tests to pure ESM ([#2044](https://github.com/ceramicnetwork/js-ceramic/issues/2044)) ([0848eb5](https://github.com/ceramicnetwork/js-ceramic/commit/0848eb59741a2b940de9dd76df94bd8948bae637))
 
 # [1.0.0-alpha.2](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@1.0.0-alpha.1...pkh-did-resolver@1.0.0-alpha.2) (2022-02-10)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 # [1.0.0-alpha.1](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.3-rc.0...pkh-did-resolver@1.0.0-alpha.1) (2022-01-14)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 # [1.0.0-alpha.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.3-rc.0...pkh-did-resolver@1.0.0-alpha.0) (2021-12-07)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [0.3.8-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.7...pkh-did-resolver@0.3.8-rc.0) (2022-01-12)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [0.3.7](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.6...pkh-did-resolver@0.3.7) (2022-01-12)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [0.3.6](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.3...pkh-did-resolver@0.3.6) (2022-01-09)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [0.3.5](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.3...pkh-did-resolver@0.3.5) (2022-01-09)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [0.3.4](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.3...pkh-did-resolver@0.3.4) (2022-01-09)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
-
 
 ## [0.3.3](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.3-rc.0...pkh-did-resolver@0.3.3) (2021-12-06)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [0.3.3-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.2...pkh-did-resolver@0.3.3-rc.0) (2021-11-17)
-
 
 ### Bug Fixes
 
-* resolve merge conflicts during merge from `main` ([#1848](https://github.com/ceramicnetwork/js-ceramic/issues/1848)) ([6772fc6](https://github.com/ceramicnetwork/js-ceramic/commit/6772fc6c61bc9daadfd3f6d6ecf3de2bb100450d))
-
-
-
-
+- resolve merge conflicts during merge from `main` ([#1848](https://github.com/ceramicnetwork/js-ceramic/issues/1848)) ([6772fc6](https://github.com/ceramicnetwork/js-ceramic/commit/6772fc6c61bc9daadfd3f6d6ecf3de2bb100450d))
 
 ## [0.3.2](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.2-rc.0...pkh-did-resolver@0.3.2) (2021-11-17)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [0.3.2-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.1...pkh-did-resolver@0.3.2-rc.0) (2021-11-12)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 ## [0.3.1](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.1-rc.0...pkh-did-resolver@0.3.1) (2021-11-12)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 ## [0.3.1-rc.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.0...pkh-did-resolver@0.3.1-rc.0) (2021-11-03)
 
 **Note:** Version bump only for package pkh-did-resolver
-
-
-
-
 
 # [0.3.0](https://github.com/ceramicnetwork/js-ceramic/compare/pkh-did-resolver@0.3.0-rc.2...pkh-did-resolver@0.3.0) (2021-11-03)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 # [0.3.0-rc.2](/compare/pkh-did-resolver@0.3.0-rc.0...pkh-did-resolver@0.3.0-rc.2) (2021-10-20)
 
 **Note:** Version bump only for package pkh-did-resolver
 
-
-
-
-
 # 0.3.0-rc.0 (2021-10-20)
-
 
 ### Features
 
-* pkh-did-resolver ([#1624](https://github.com/ceramicnetwork/js-ceramic/issues/1624)) ([489719b](https://github.com/ceramicnetwork/js-ceramic/commit/489719b6dbd4e87d6f1d87c0d1b6967519ba46b1))
+- pkh-did-resolver ([#1624](https://github.com/ceramicnetwork/js-ceramic/issues/1624)) ([489719b](https://github.com/ceramicnetwork/js-ceramic/commit/489719b6dbd4e87d6f1d87c0d1b6967519ba46b1))

--- a/packages/pkh-did-resolver/package.json
+++ b/packages/pkh-did-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkh-did-resolver",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "did:pkh method resolver",
   "keywords": [
     "ceramic",

--- a/packages/pkh-ethereum/CHANGELOG.md
+++ b/packages/pkh-ethereum/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @didtools/pkh-ethereum
 
+## 0.5.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - @didtools/cacao@3.0.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/pkh-ethereum/package.json
+++ b/packages/pkh-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/pkh-ethereum",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",
@@ -47,7 +47,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@didtools/cacao": "workspace:^2.1.0",
+    "@didtools/cacao": "workspace:^3.0.0",
     "@noble/curves": "^1.2.0",
     "@noble/hashes": "^1.3.2",
     "@stablelib/random": "^1.0.2",

--- a/packages/pkh-solana/CHANGELOG.md
+++ b/packages/pkh-solana/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @didtools/pkh-solana
+
+## 0.2.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - @didtools/cacao@3.0.0

--- a/packages/pkh-solana/package.json
+++ b/packages/pkh-solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/pkh-solana",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",
@@ -47,7 +47,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@didtools/cacao": "workspace:^2.0.0",
+    "@didtools/cacao": "workspace:^3.0.0",
     "@noble/curves": "^1.2.0",
     "@stablelib/random": "^1.0.2",
     "caip": "^1.1.0",

--- a/packages/pkh-stacks/CHANGELOG.md
+++ b/packages/pkh-stacks/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @didtools/pkh-stacks
+
+## 0.2.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - @didtools/cacao@3.0.0

--- a/packages/pkh-stacks/package.json
+++ b/packages/pkh-stacks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/pkh-stacks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",
   "main": "dist/index.js",
@@ -46,7 +46,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@didtools/cacao": "workspace:^2.0.0",
+    "@didtools/cacao": "workspace:^3.0.0",
     "@stablelib/random": "^1.0.2",
     "@stacks/common": "^6.10.0",
     "@stacks/encryption": "^6.10.0",

--- a/packages/pkh-tezos/CHANGELOG.md
+++ b/packages/pkh-tezos/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @didtools/pkh-tezos
+
+## 0.3.0
+
+### Minor Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
+### Patch Changes
+
+- Updated dependencies
+  - @didtools/cacao@3.0.0

--- a/packages/pkh-tezos/package.json
+++ b/packages/pkh-tezos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/pkh-tezos",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@didtools/cacao": "workspace:^2.0.0",
+    "@didtools/cacao": "workspace:^3.0.0",
     "@noble/curves": "^1.2.0",
     "@noble/hashes": "^1.3.2",
     "@stablelib/random": "^1.0.2",

--- a/packages/siwx/CHANGELOG.md
+++ b/packages/siwx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @didtools/siwx
 
+## 2.0.0
+
+### Major Changes
+
+- Upgrade to multiformats 13 and related packages impacted
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/siwx/package.json
+++ b/packages/siwx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/siwx",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Typescript library for Sign-In With X",
   "author": "Sergey Ukustov <sergey@ukstv.me>",
   "license": "(Apache-2.0 OR MIT)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,7 +352,7 @@ importers:
         specifier: ^7.4.5
         version: 7.4.5
       dids:
-        specifier: workspace:^4.0.1
+        specifier: workspace:^5.0.0
         version: link:../dids
       jest-environment-jsdom:
         specifier: ^29.7.0
@@ -452,7 +452,7 @@ importers:
   packages/pkh-ethereum:
     dependencies:
       '@didtools/cacao':
-        specifier: workspace:^2.1.0
+        specifier: workspace:^3.0.0
         version: link:../cacao
       '@noble/curves':
         specifier: ^1.2.0
@@ -474,7 +474,7 @@ importers:
   packages/pkh-solana:
     dependencies:
       '@didtools/cacao':
-        specifier: workspace:^2.0.0
+        specifier: workspace:^3.0.0
         version: link:../cacao
       '@noble/curves':
         specifier: ^1.2.0
@@ -496,7 +496,7 @@ importers:
   packages/pkh-stacks:
     dependencies:
       '@didtools/cacao':
-        specifier: workspace:^2.0.0
+        specifier: workspace:^3.0.0
         version: link:../cacao
       '@stablelib/random':
         specifier: ^1.0.2
@@ -524,7 +524,7 @@ importers:
   packages/pkh-tezos:
     dependencies:
       '@didtools/cacao':
-        specifier: workspace:^2.0.0
+        specifier: workspace:^3.0.0
         version: link:../cacao
       '@noble/curves':
         specifier: ^1.2.0
@@ -609,7 +609,7 @@ importers:
         version: 1.0.7
       docusaurus-plugin-typedoc:
         specifier: ^0.21.0
-        version: 0.21.0(typedoc-plugin-markdown@3.17.1)(typedoc@0.25.6)
+        version: 0.21.0(typedoc-plugin-markdown@3.17.1)(typedoc@0.25.4)
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
@@ -10266,14 +10266,14 @@ packages:
     dependencies:
       esutils: 2.0.3
 
-  /docusaurus-plugin-typedoc@0.21.0(typedoc-plugin-markdown@3.17.1)(typedoc@0.25.6):
+  /docusaurus-plugin-typedoc@0.21.0(typedoc-plugin-markdown@3.17.1)(typedoc@0.25.4):
     resolution: {integrity: sha512-7DLFrf0JP+L5vSRQHVKIbndjbksd2MlxPqNmmdxzLFiRINgrY23s9waduWM9t24PUsf5JZ0tlGKlE3sK4uZ72Q==}
     peerDependencies:
       typedoc: '>=0.24.0'
       typedoc-plugin-markdown: '>=3.15.0'
     dependencies:
-      typedoc: 0.25.6(typescript@5.3.2)
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.6)
+      typedoc: 0.25.4(typescript@5.3.2)
+      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.4)
     dev: true
 
   /dom-converter@0.2.0:
@@ -19169,16 +19169,21 @@ packages:
       typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.8
-      typedoc: 0.25.4(typescript@5.3.3)
+      typedoc: 0.25.4(typescript@5.3.2)
     dev: true
 
-  /typedoc-plugin-markdown@3.17.1(typedoc@0.25.6):
-    resolution: {integrity: sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==}
+  /typedoc@0.25.4(typescript@5.3.2):
+    resolution: {integrity: sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==}
+    engines: {node: '>= 16'}
+    hasBin: true
     peerDependencies:
-      typedoc: '>=0.24.0'
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
     dependencies:
-      handlebars: 4.7.8
-      typedoc: 0.25.6(typescript@5.3.2)
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.3
+      shiki: 0.14.7
+      typescript: 5.3.2
     dev: true
 
   /typedoc@0.25.4(typescript@5.3.3):
@@ -19193,20 +19198,6 @@ packages:
       minimatch: 9.0.3
       shiki: 0.14.7
       typescript: 5.3.3
-    dev: true
-
-  /typedoc@0.25.6(typescript@5.3.2):
-    resolution: {integrity: sha512-1rdionQMpOkpA58qfym1J+YD+ukyA1IEIa4VZahQI2ZORez7dhOvEyUotQL/8rSoMBopdzOS+vAIsORpQO4cTA==}
-    engines: {node: '>= 16'}
-    hasBin: true
-    peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.3
-      shiki: 0.14.7
-      typescript: 5.3.2
     dev: true
 
   /typeforce@1.18.0:


### PR DESCRIPTION
dids@5.0.0, did-session@3.0.0, @didtools/codecs@2.0.0, @didtools/cacao@3.0.0, @didtools/pkh-solana@0.2.0, @didtools/pkh-tezos@0.3.0, key-did-provider-ed25519@4.0.0, key-did-resolver@4.0.0, @didtools/key-webauth@2.0.0, @didtools/key-webauthn@2.0.0, @didtools/key-secp256k1@0.3.0, @didtools/key-webcrypto@0.2.0, @didtools/multidid@0.1.0