### PR TITLE
fix(dids): Verify eip55 formatted CACAOs correctly

### DIFF
--- a/packages/dids/src/did.ts
+++ b/packages/dids/src/did.ts
@@ -113,6 +113,14 @@ function isResolver(resolver: Resolver | ResolverRegistry): resolver is Resolver
   return 'registry' in resolver && 'cache' in resolver
 }
 
+function issuerEquals(dida: string, didb: string): boolean {
+  if (dida === didb) return true
+  if (dida.startsWith('did:pkh:eip155:1:')) {
+    return dida.toLowerCase() === didb.toLowerCase()
+  }
+  return false
+}
+
 /**
  * Interact with DIDs.
  */
@@ -368,7 +376,7 @@ export class DID {
     const signerDid = didResolutionResult.didDocument?.id
     if (
       options.issuer &&
-      options.issuer === options.capability?.p.iss &&
+      issuerEquals(options.issuer, options.capability?.p.iss) &&
       signerDid === options.capability.p.aud
     ) {
       if (!options.verifiers) throw new Error('Registered verifiers needed for CACAO')

--- a/packages/dids/src/did.ts
+++ b/packages/dids/src/did.ts
@@ -376,6 +376,7 @@ export class DID {
     const signerDid = didResolutionResult.didDocument?.id
     if (
       options.issuer &&
+      options.capability &&
       issuerEquals(options.issuer, options.capability?.p.iss) &&
       signerDid === options.capability.p.aud
     ) {

--- a/packages/dids/test/provider-behavior.test.ts
+++ b/packages/dids/test/provider-behavior.test.ts
@@ -375,9 +375,10 @@ describe('`createDagJWS method`', () => {
     expect(did.hasCapability).toBe(true)
 
     // Valid capability
+    // Ceramic always uses lower case DID PKH for eip155
     await expect(
       did.verifyJWS(res.jws, {
-        issuer: `did:pkh:eip155:1:${wallet.address}`,
+        issuer: `did:pkh:eip155:1:${wallet.address.toLowerCase()}`,
         capability: cacao,
         atTime: new Date('2021-10-30T16:25:24.000Z'),
       }),


### PR DESCRIPTION
There was a bug introduced in #176 where CACAO/SIWE message signed with eip55 encoding would result in an  `unsupportedDidMethod` error. This was because an equality check would fail due to the difference between a lower case and a mixed case (eip55) ethereum address. This PR fixes this problem.