### PR TITLE
chore: release dids@5.0.1, did-session@3.0.2, key-did-provider-ed25519@4.0.2, @didtools/key-secp256k1@0.3.2

### DIFF
--- a/packages/did-session/CHANGELOG.md
+++ b/packages/did-session/CHANGELOG.md
@@ -1,5 +1,13 @@
 # did-session
 
+## 3.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - dids@5.0.2
+  - key-did-provider-ed25519@4.0.2
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/did-session/package.json
+++ b/packages/did-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-session",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Manage user DIDs in a web environment",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/dids/CHANGELOG.md
+++ b/packages/dids/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## v2.4.0 (2021-07-12)
 
+## 5.0.2
+
+### Patch Changes
+
+- Verify eip55 formatted CACAOs correctly
+
 ## 5.0.1
 
 ### Patch Changes

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dids",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Typescript library for interacting with DIDs",
   "author": "Joel Thorstensson <oed@3box.io>",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/key-did-provider-ed25519/CHANGELOG.md
+++ b/packages/key-did-provider-ed25519/CHANGELOG.md
@@ -1,5 +1,12 @@
 # key-did-provider-ed25519
 
+## 4.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - dids@5.0.2
+
 ## 4.0.1
 
 ### Patch Changes

--- a/packages/key-did-provider-ed25519/package.json
+++ b/packages/key-did-provider-ed25519/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-did-provider-ed25519",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "author": "Joel Thorstensson",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",

--- a/packages/key-did-provider-secp256k1/CHANGELOG.md
+++ b/packages/key-did-provider-secp256k1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @didtools/key-secp256k1
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - dids@5.0.2
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/key-did-provider-secp256k1/package.json
+++ b/packages/key-did-provider-secp256k1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didtools/key-secp256k1",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Joel Thorstensson",
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",


### PR DESCRIPTION
Release new patch version of dids with #184 